### PR TITLE
Add support for `symlink` & `apple` file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,4 @@ This is equivalent to running "Reconcile Offline Work" followed by "Revert Uncha
 It has only been tested on our repositories, so it may not work for you if you use configuration different from ours.  
 Use the dry run mode first to see whether it is working as intended. You are responsible for changes made to your repository.
 
-- The `apple` digest type on depot files is not supported. This is not normally used.
 - `p4-fast-reconcile` does not implement move/add/delete pair detection.


### PR DESCRIPTION
Treat symlink filetypes like plaintext, which is how they're handled on Windows without symlink support enabled. (The default.)

Pass Apple filetypes to `p4 reconcile` to fall back to the default handling.

Also verify that all files we're digesting are plain files, to catch any cases where we'd produce an unexpected result.

Fixes GH-1.