### PR TITLE
Fix "Directory not found" issue on Linux based systems

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1549,7 +1549,11 @@ fn main() -> Result<()> {
             }
         }
         // Correct the path since P4V tends to give us a bad one
-        let mut path = path.trim_end_matches("\\...").to_owned();
+        if cfg!(windows) {
+            path = path.trim_end_matches("\\...").to_owned();
+        } else if cfg!(unix) {
+            path = path.trim_end_matches("/...").to_owned();
+        }
         if let Some(first_letter) = path.get_mut(0..1) {
             first_letter.make_ascii_uppercase();
         }


### PR DESCRIPTION
I currently use p4v on Linux, there was an issue where I was getting "directory not found" because of the windows \\... line ending. So I added a OS configuration that seems to work (I would prefer someone on Windows test that I didn't break anything on your side, although this was such a minor change I don't think so)

It works on Ubuntu 24.04 with P4V Rev. P4V/LINUX26X86_64/2024.4/2690487